### PR TITLE
Added space for PkgVersion insertion by Dist::Zilla

### DIFF
--- a/lib/MooseX/OneArgNew.pm
+++ b/lib/MooseX/OneArgNew.pm
@@ -1,4 +1,5 @@
 package MooseX::OneArgNew;
+
 use MooseX::Role::Parameterized 1.0;
 # ABSTRACT: teach ->new to accept single, non-hashref arguments
 


### PR DESCRIPTION
I really don't want to be that guy, but I added an extra line so that `PkgVersion` can insert a `$VERSION`.

This only came to my attention since it was blocking me from running `dzil test` while I was debugging an issue packaging it.
