### PR TITLE
Coerce upgrading MooseX::Role::Parameterizable on newer CMOP installs.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -4,3 +4,16 @@ license = Perl_5
 copyright_holder = Ricardo Signes
 
 [@RJBS]
+
+[DynamicPrereqs]
+:version = 0.010
+-include_sub = can_use
+-delimiter = |
+-raw = |# This version of old versions of MooseX::Role::Parameterised are broken by newer Class::MOP
+-raw = |{
+-raw = |  my ($broken, $fixedver) = ( "MooseX::Role::Parameterized", "1.01"  );
+-raw = |  my ($breaker,$breakver) = ( "Class::MOP",                  "2.1100");
+-raw = |  if( can_use($breaker, $breakver) and not can_use($broken,$fixedver) ) {
+-raw = |    $WriteMakefileArgs{PREREQ_PM}{$broken} = $FallbackPrereqs{$broken} = $fixedver;
+-raw = |  }
+-raw = |}


### PR DESCRIPTION
Class::MOP deprecated the load_class method a while ago, and MXRP
shipped a fixed version.

However, there are still boxes running tests with both the newer
Class::MOP and the older MXRP because nothing has tripped the boxes into
fixing their situation.

Example smoke that ran just today:
http://www.cpantesters.org/cpan/report/809a12e8-6bf6-1014-b3c6-8fb89162f7eb